### PR TITLE
Fixed Hashing and Removed Participant Identifiers in the app

### DIFF
--- a/ios/SensingApp/SensingApp/MainAppView.swift
+++ b/ios/SensingApp/SensingApp/MainAppView.swift
@@ -512,10 +512,7 @@ struct MainAppView: View {
         @ObservedObject var appState: AppState
         @Binding var isSurveyPresented: Bool
 
-        @EnvironmentObject private var authManager: SecureAuthManager
-
         @AppStorage("journey_first_open_date") private var firstOpenTimestamp: Double = 0
-        @AppStorage("journey_display_name") private var storedDisplayName: String = ""
 
         private var currentDay: Int {
             guard firstOpenTimestamp != 0 else { return 1 }
@@ -523,11 +520,6 @@ struct MainAppView: View {
             let start = cal.startOfDay(for: Date(timeIntervalSince1970: firstOpenTimestamp))
             let today = cal.startOfDay(for: Date())
             return max(1, (cal.dateComponents([.day], from: start, to: today).day ?? 0) + 1)
-        }
-
-        private var patientFirstName: String? {
-            guard !storedDisplayName.isEmpty else { return nil }
-            return storedDisplayName.components(separatedBy: .whitespaces).first
         }
 
         private var checkInComplete: Bool { appState.isCompletedToday }
@@ -560,7 +552,7 @@ struct MainAppView: View {
                                 Text(greetingText)
                                     .font(.system(size: 14, weight: .medium, design: .rounded))
                                     .foregroundStyle(Color(red: 0.55, green: 0.47, blue: 0.44))
-                                Text(patientFirstName.map { "Hi, \($0) 👋" } ?? "Hi there 👋")
+                                Text("Hi there 👋")
                                     .font(.system(size: 28, weight: .bold, design: .rounded))
                                     .foregroundStyle(Color(red: 0.28, green: 0.22, blue: 0.20))
                             }
@@ -618,7 +610,6 @@ struct MainAppView: View {
                 appeared = true
                 if firstOpenTimestamp == 0 { firstOpenTimestamp = Date().timeIntervalSince1970 }
                 loadTodayHealthStats()
-                Task { await authManager.refreshPatientProfileCache() }
             }
         }
 
@@ -888,12 +879,6 @@ struct MainAppView: View {
         @State private var showingLogoutAlert = false
         @State private var showingPrivacySheet = false
         @State private var showingHelpSheet = false
-        @AppStorage("journey_display_name") private var storedDisplayName: String = ""
-
-        private var displayName: String {
-            storedDisplayName.isEmpty ? "Patient" : storedDisplayName
-        }
-
         var body: some View {
             NavigationStack {
                 ZStack {
@@ -918,7 +903,7 @@ struct MainAppView: View {
                                     .foregroundStyle(accentColor)
                             }
                             VStack(alignment: .leading, spacing: 3) {
-                                Text(displayName)
+                                Text("User")
                                     .font(.system(size: 17, weight: .semibold, design: .rounded))
                                     .foregroundStyle(Color(red: 0.28, green: 0.22, blue: 0.20))
                                 Text("Journey Study Participant")

--- a/ios/SensingApp/SensingApp/Survey/SurveyUploader.swift
+++ b/ios/SensingApp/SensingApp/Survey/SurveyUploader.swift
@@ -112,7 +112,7 @@ final class SurveyUploader {
 
         let timestampUTC  = isoFormatter.string(from: now)
         let timestampUnix = Int(now.timeIntervalSince1970)
-        let userID        = surveyData["user_id"] as? String ?? "unknown"
+        let userID        = surveyData["user_id"] as? String ?? ParticipantID.current
 
         // MARK: Build Wrapped Payload (identical to original)
         let wrappedPayload: [String: Any] = [

--- a/ios/SensingApp/SensingApp/login/KeychainManager.swift
+++ b/ios/SensingApp/SensingApp/login/KeychainManager.swift
@@ -23,13 +23,16 @@ import Security
 // STORED KEYS (set by SecureAuthManager):
 //   "journey_access_token"    — short-lived JWT for API requests
 //   "journey_refresh_token"   — long-lived token for silent re-auth
-//   "journey_apple_user_id"   — Apple's stable user identifier string
+//   (The raw Apple user ID is NOT stored — only its one-way hash, in
+//    UserDefaults via ParticipantID — so no re-identification key is kept.)
 //
 // ACCESSIBILITY:
-//   kSecAttrAccessibleAfterFirstUnlock is used so tokens remain
-//   readable after the device is unlocked once — this supports
+//   kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly is used so tokens
+//   remain readable after the device is unlocked once — this supports
 //   background tasks and silent refresh on app relaunch without
-//   requiring the user to unlock the device first.
+//   requiring the user to unlock the device first. "ThisDeviceOnly"
+//   keeps tokens out of encrypted backups, so they never migrate to
+//   another device (PHI hardening) — the user re-authenticates instead.
 //
 // USAGE:
 //   KeychainManager.shared.save(key: "my_key", data: Data("value".utf8))
@@ -64,15 +67,15 @@ class KeychainManager {
     // then re-added — standard upsert pattern for Keychain since
     // SecItemUpdate requires more complex handling.
     //
-    // kSecAttrAccessibleAfterFirstUnlock ensures the item is readable
-    // after the first device unlock, which is required for background
-    // token refresh to work without the user actively using the device.
+    // kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly ensures the item is
+    // readable after the first device unlock (required for background token
+    // refresh) while never leaving the device via iCloud or encrypted backups.
     func save(key: String, data: Data) {
         let query: [CFString: Any] = [
             kSecClass:          kSecClassGenericPassword,
             kSecAttrAccount:    key,
             kSecValueData:      data,
-            kSecAttrAccessible: kSecAttrAccessibleAfterFirstUnlock  // ← required for background refresh
+            kSecAttrAccessible: kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly  // ← background refresh; ThisDeviceOnly = never restored to another device via backup
         ]
         SecItemDelete(query as CFDictionary)
         SecItemAdd(query as CFDictionary, nil)

--- a/ios/SensingApp/SensingApp/login/SecureAuthManager.swift
+++ b/ios/SensingApp/SensingApp/login/SecureAuthManager.swift
@@ -30,10 +30,10 @@ internal import Combine
 //
 // FLOW:
 //   1. Patient taps "Sign in with Apple"
-//   2. Apple returns a one-time identity token (JWT) + optional full name
-//   3. App sends { identity_token, full_name? } to POST /auth/login
+//   2. Apple returns a one-time identity token (JWT)
+//   3. App sends { identity_token } to POST /auth/login
 //   4. Backend verifies our access code and returns { access_token, refresh_token }
-//   5. Both tokens stored securely in iOS Keychain (maybe change it if not implemented)
+//   5. Both tokens stored securely in iOS Keychain via KeychainManager
 //   6. Every subsequent API call uses access token as Bearer header
 //   7. On app relaunch, silentRefresh() restores session automatically
 //   8. On 401 from any API call → refresh access token → retry once
@@ -41,10 +41,11 @@ internal import Combine
 //  10. Logout calls POST /auth/logout (invalidates refresh token server-side)
 //      then clears all tokens from Keychain
 //
-// IMPORTANT — FULL NAME:
-//   Apple only provides the user's full name on the very first login ever.
-//   It is nil on all subsequent logins. Send it when present — backend
-//   discards it if the user already exists.
+// IMPORTANT — ANONYMITY:
+//   The patient's name is never stored or transmitted. At login the app
+//   derives a stable, one-way SHA-256 hash of Apple's per-user identifier
+//   (ParticipantID) and tags all uploaded data with it, so a participant's
+//   data links correctly in the backend without revealing who they are.
 //
 // ============================================================
 
@@ -71,12 +72,6 @@ private let demoMode = true
 // token_expired (just needs refresh).
 private struct BackendErrorResponse: Decodable {
     let error: String
-}
-
-// MARK: - Patient Profile Response
-private struct PatientProfileResponse: Decodable {
-    let full_name: String?
-    let surgery_date: String?
 }
 
 // MARK: - Token Response Models
@@ -175,10 +170,10 @@ class SecureAuthManager: ObservableObject {
     // Throws: AuthError
     func login(identityToken: String, fullName: String?, appleUserID: String) async throws {
 
-        // Persist display name for both demo and real paths — runs before any branch.
-        if let fullName, !fullName.isEmpty {
-            UserDefaults.standard.set(fullName, forKey: "journey_display_name")
-        }
+        // Derive and persist the anonymous participant hash for both demo and
+        // real paths — runs before any branch so demo sessions get one too.
+        // The patient's name is intentionally never stored or uploaded.
+        ParticipantID.store(forAppleUserID: appleUserID)
 
         // ── ⚠️ DEMO MODE BLOCK — DELETE BEFORE SHIPPING ─────────────
         if demoMode {
@@ -194,10 +189,9 @@ class SecureAuthManager: ObservableObject {
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         request.timeoutInterval = 15
 
-        // Only include full_name when Apple actually provided it.
-        // Backend ignores it for existing users; stores it for new ones.
-        var body: [String: String] = ["identity_token": identityToken]
-        if let name = fullName { body["full_name"] = name }
+        // Identity is conveyed solely by the Apple identity token; the
+        // patient's name is never transmitted.
+        let body: [String: String] = ["identity_token": identityToken]
         request.httpBody = try JSONEncoder().encode(body)
 
         let (data, response) = try await session.data(for: request)
@@ -212,9 +206,8 @@ class SecureAuthManager: ObservableObject {
                 throw AuthError.decodingError
             }
             storeTokens(
-                access:      tokens.accessToken,
-                refresh:     tokens.refreshToken,
-                appleUserID: appleUserID
+                access:  tokens.accessToken,
+                refresh: tokens.refreshToken
             )
             isAuthenticated = true
 
@@ -400,37 +393,15 @@ class SecureAuthManager: ObservableObject {
         isAuthenticated = false
     }
 
-    // MARK: - Patient Profile
-    //
-    // Fetches the patient's display name from the backend and caches it in
-    // UserDefaults ("journey_display_name") so the Home/Settings views
-    // show the correct name. Fails silently — demo mode returns immediately,
-    // and any network/decode error leaves the cached value untouched.
-    //
-    // ENDPOINT CONTRACT (backend team — not yet implemented server-side):
-    //   GET {baseURL}/api/patient/profile
-    //   Authorization: Bearer <access token>
-    //   200 → { "full_name": "Jane Doe", "surgery_date": "2026-06-02" }
-    //   Only "full_name" is consumed here; "surgery_date" is ignored.
-    func refreshPatientProfileCache() async {
-        guard !demoMode else { return }
-        do {
-            let data = try await authenticatedRequest(endpoint: "/api/patient/profile")
-            let profile = try JSONDecoder().decode(PatientProfileResponse.self, from: data)
-            if let name = profile.full_name, !name.isEmpty {
-                UserDefaults.standard.set(name, forKey: "journey_display_name")
-            }
-        } catch {
-            print("refreshPatientProfileCache: \(error)")
-        }
-    }
-
     // MARK: - Private Helpers
 
-    private func storeTokens(access: String, refresh: String, appleUserID: String) {
+    private func storeTokens(access: String, refresh: String) {
         KeychainManager.shared.save(key: accessTokenKey,  data: Data(access.utf8))
         KeychainManager.shared.save(key: refreshTokenKey, data: Data(refresh.utf8))
-        KeychainManager.shared.save(key: appleUserIDKey,  data: Data(appleUserID.utf8))
+        // NOTE: the raw Apple user ID is intentionally NOT stored — only the
+        // one-way ParticipantID hash (UserDefaults) is kept, so the device
+        // never holds a raw re-identification key. clearTokens() still deletes
+        // appleUserIDKey to purge any value written by earlier builds.
     }
 
     private func clearTokens() {

--- a/ios/SensingApp/SensingApp/util/ParticipantID.swift
+++ b/ios/SensingApp/SensingApp/util/ParticipantID.swift
@@ -1,0 +1,44 @@
+//
+//  ParticipantID.swift
+//  SensingApp
+//
+//  Anonymous participant identifier.
+//
+//  The app never stores or uploads the patient's name or Apple account.
+//  Instead every piece of collected data is tagged with a stable
+//  SHA-256 hash of Apple's per-app user identifier (credential.user).
+//  This keeps each participant's data correctly linked in the backend
+//  WITHOUT revealing who they are:
+//    • Deterministic — the same Apple ID always maps to the same bucket
+//      (across reinstalls and devices), so data links correctly.
+//    • One-way — the patient cannot be recovered from the hash.
+//    • The raw Apple identifier is never uploaded; only this hash leaves
+//      the device.
+//
+
+import Foundation
+import CryptoKit
+
+enum ParticipantID {
+
+    /// UserDefaults key holding the current participant hash.
+    private static let storageKey = "journey_participant_id"
+
+    /// SHA-256 (lowercase hex) of the given Apple user identifier.
+    static func hash(_ appleUserID: String) -> String {
+        let digest = SHA256.hash(data: Data(appleUserID.utf8))
+        return digest.map { String(format: "%02x", $0) }.joined()
+    }
+
+    /// Compute the participant hash from the Apple user ID and persist it so
+    /// every uploader can stamp it on outgoing data. Call once at login.
+    static func store(forAppleUserID appleUserID: String) {
+        UserDefaults.standard.set(hash(appleUserID), forKey: storageKey)
+    }
+
+    /// The current participant hash, or a neutral placeholder if login has
+    /// not happened yet. Read by all upload paths.
+    static var current: String {
+        UserDefaults.standard.string(forKey: storageKey) ?? "unidentified"
+    }
+}

--- a/ios/SensingApp/SensingApp/util/S3Uploader.swift
+++ b/ios/SensingApp/SensingApp/util/S3Uploader.swift
@@ -22,7 +22,7 @@ public enum S3UploadConfig {
     public nonisolated(unsafe) static let baseURL      = _baseURL
     public nonisolated(unsafe) static let presignURL   = "\(_baseURL)/api/noauth/uploads/presign"
     public nonisolated(unsafe) static let completeURL  = "\(_baseURL)/api/noauth/uploads/complete"
-    public nonisolated(unsafe) static let participantID = "P0001"   // change to a real test participant
+    public static var participantID: String { ParticipantID.current }   // anonymous SHA-256 participant hash
 }
 
 // Top-level aliases for backwards compatibility

--- a/ios/SensingApp/SensingApp/util/UploadToServer.swift
+++ b/ios/SensingApp/SensingApp/util/UploadToServer.swift
@@ -23,7 +23,7 @@ class UploadToServer {
         let body : [String: Any] = [
             "title": "Upload device token",
             "deviceToken": deviceToken,
-            "userId": "sub0x"
+            "userId": ParticipantID.current
         ]
         
         let responseMessage: String = await self.sendPostRequest(linktoPost: linkToPost, postBody: body)

--- a/ios/SensingApp/SensingApp/util/Uploader.swift
+++ b/ios/SensingApp/SensingApp/util/Uploader.swift
@@ -118,7 +118,7 @@ struct Uploader {
         let parameters = [
             [
                 "key": "participantId",
-                "value": "P0001",
+                "value": ParticipantID.current,
                 "type": "text"
             ],
             [


### PR DESCRIPTION
- unified hashing via apple sign in and SHA256
- made apple login is correctly hashed and linked to all the data coming from the app
- removed any identifiers in the app
- created a new participantid file that does the hashing of the login