### PR TITLE
Stop live location from draining battery on the Sensors tab

### DIFF
--- a/ios/SensingApp/SensingApp/LiveLocationManager.swift
+++ b/ios/SensingApp/SensingApp/LiveLocationManager.swift
@@ -23,6 +23,11 @@ class LiveLocationManager: NSObject, ObservableObject, CLLocationManagerDelegate
     @Published var lastUpdate: Date?
     @Published var isTracking = false
 
+    // Whether the patient wants live location shown. Kept separate from
+    // isTracking so leaving the tab can stop the GPS without flipping
+    // the toggle off underneath them.
+    private(set) var userEnabled = true
+
     var authorizationStatus: CLAuthorizationStatus {
         manager.authorizationStatus
     }
@@ -30,7 +35,14 @@ class LiveLocationManager: NSObject, ObservableObject, CLLocationManagerDelegate
     override init() {
         super.init()
         manager.delegate = self
-        manager.desiredAccuracy = kCLLocationAccuracyBest
+
+        // This drives a coordinate label, not the research pipeline, so it does
+        // not need GPS-grade accuracy. Requesting Best with no distance filter
+        // pins the GPS on for the whole app: CoreLocation powers the hardware to
+        // satisfy the most demanding active client, which would override
+        // AdaptiveLocationManager whenever it drops to low power.
+        manager.desiredAccuracy = kCLLocationAccuracyNearestTenMeters
+        manager.distanceFilter = 10
     }
 
     func start() {
@@ -44,7 +56,15 @@ class LiveLocationManager: NSObject, ObservableObject, CLLocationManagerDelegate
         isTracking = false
     }
 
+    // Called when the Sensors tab appears. Honours the toggle so returning to
+    // the tab does not silently restart location the patient turned off.
+    func resumeIfEnabled() {
+        guard userEnabled else { return }
+        start()
+    }
+
     func setTracking(_ enabled: Bool) {
+        userEnabled = enabled
         enabled ? start() : stop()
     }
 

--- a/ios/SensingApp/SensingApp/Views/SensorsTabView.swift
+++ b/ios/SensingApp/SensingApp/Views/SensorsTabView.swift
@@ -183,8 +183,14 @@ struct SensorsTabView: View {
             }
             .navigationTitle("What We Collect")
             .onAppear {
-                locationManager.start()
+                locationManager.resumeIfEnabled()
                 healthManager.refreshWithNewRange(days: 1) { _ in }
+            }
+            // The live coordinate is only visible on this tab. Without this the
+            // GPS keeps streaming after the patient navigates away, for the rest
+            // of the app's lifetime.
+            .onDisappear {
+                locationManager.stop()
             }
         }
     }


### PR DESCRIPTION
- LiveLocationManager: drop desiredAccuracy from Best (no distance filter) to nearestTenMeters with a 10m filter. The live coordinate label does not need GPS-grade accuracy, and requesting Best pinned the GPS on app-wide, which overrode AdaptiveLocationManager whenever it dropped to low power.
- SensorsTabView: stop location on disappear; it previously kept streaming for the rest of the app's lifetime after leaving the tab.
- Add userEnabled/resumeIfEnabled so returning to the tab does not silently restart location the patient turned off.